### PR TITLE
chop off * character before processing directive

### DIFF
--- a/src/lynx-data-parser.ts
+++ b/src/lynx-data-parser.ts
@@ -66,7 +66,12 @@ function parseResults(message: string): LynxResults {
 export function parseLynxPacket(
   message: string
 ): { isDirective: boolean; data: LynxResults | LynxDirective } {
-  const isDirective = message.startsWith("*");
+  // Check if directive 
+  let isDirective = false;
+  if (message.startsWith("*")) {
+    isDirective = true;
+    message = message.substr(1); // Chop off *
+  }
   return {
     isDirective: isDirective,
     data: isDirective ? parseDirective(message) : parseResults(message),


### PR DESCRIPTION
Better to chop off the '*' character at this point so it does not end up in the title of the directive.